### PR TITLE
Rename title to businessName in dataset output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example results item:
 
 ```text
 {
-  "title": "Scotiabank",
+  "businessName": "Scotiabank",
   "totalScore": 3.7,
   "categoryName": "Bank",
   "address": "201 Bishopsgate, London EC2M 3NS, UK",

--- a/src/places_crawler.js
+++ b/src/places_crawler.js
@@ -18,7 +18,7 @@ const extractPlaceDetail = async (page, includeReviews, includeImages) => {
     await page.waitForSelector(PLACE_TITLE_SEL, { timeout: DEFAULT_TIMEOUT });
     const detail = await page.evaluate((placeTitleSel) => {
         return {
-            title: $(placeTitleSel).text().trim(),
+            businessName: $(placeTitleSel).text().trim(),
             totalScore: $('span.section-star-display').eq(0).text().trim(),
             categoryName: $('[jsaction="pane.rating.category"]').text().trim(),
             address: $('[data-section-id="ad"] .widget-pane-link').text().trim(),

--- a/src/result_item_schema.json
+++ b/src/result_item_schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "title": "The Root Schema",
   "required": [
-    "title",
+    "businessName",
     "totalScore",
     "categoryName",
     "address",
@@ -16,7 +16,7 @@
     "url"
   ],
   "properties": {
-    "title": {
+    "businessName": {
       "$id": "#/properties/title",
       "type": "string",
       "title": "The Title Schema",


### PR DESCRIPTION
It better describes what the value is and it will show up in the beginning of tabular data, because there can be 140+ columns for images and then the `title` field takes a lot of scrolling to get to and it's the main attribute.