### PR TITLE
Fix invalid main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "crawler-google-places",
     "version": "1.0.0",
     "description": "",
-    "main": "main.js",
+    "main": "src/main.js",
     "scripts": {
         "test-local": "mocha --file ./test/crawler.local.js",
         "test-platform": "mocha --file ./test/crawler.platform.js",


### PR DESCRIPTION
The "main" entry for the NPM package seems to be invalid, since there is no "main.js" in the root folder. This can result in the error message
```
Please verify that the package.json has a valid "main" entry
```
The commit in this PR should fix it