### PR TITLE
Fix consent screen handling

### DIFF
--- a/src/places_crawler.js
+++ b/src/places_crawler.js
@@ -30,8 +30,6 @@ const handlePageFunctionExtended = async ({ pageContext, scrapingOptions, crawle
 
     const { label, searchString } = /** @type {{ label: string, searchString: string }} */ (request.userData);
 
-    await injectJQuery(page);
-
     const logLabel = label === 'startUrl' ? 'SEARCH' : 'PLACE';
 
     // TODO: Figure out how to remove the timeout and still handle consent screen
@@ -43,6 +41,8 @@ const handlePageFunctionExtended = async ({ pageContext, scrapingOptions, crawle
         // @ts-ignore  I'm not sure how we could fix the types here
         await waiter(() => request.userData.waitingForConsent === false);
     }
+
+    await injectJQuery(page);
 
     try {
         // Check if Google shows captcha
@@ -139,7 +139,7 @@ const setUpCrawler = ({ crawlerOptions, scrapingOptions, stats, errorSnapshotter
             // Handle consent screen, it takes time before the iframe loads so we need to update userData
             // and block handlePageFunction from continuing until we click on that
             page.on('response', async (res) => {
-                if (res.url().match(/consent\.google\.[a-z.]+\/intro/)) {
+                if (res.url().match(/consent\.google\.[a-z.]+\/(?:intro|m\?)/)) {
                     log.warning('Consent screen loading, we need to approve first!');
                     // @ts-ignore
                     request.userData.waitingForConsent = true;

--- a/src/places_crawler.js
+++ b/src/places_crawler.js
@@ -8,7 +8,7 @@ const ErrorSnapshotter = require('./error-snapshotter'); // eslint-disable-line 
 const { enqueueAllPlaceDetails } = require('./enqueue_places');
 const { handlePlaceDetail } = require('./detail_page_handle');
 const {
-    waitAndHandleConsentFrame, waiter,
+    waitAndHandleConsentScreen, waiter,
 } = require('./utils');
 
 const { log } = Apify.utils;
@@ -144,7 +144,7 @@ const setUpCrawler = ({ crawlerOptions, scrapingOptions, stats, errorSnapshotter
                     // @ts-ignore
                     request.userData.waitingForConsent = true;
                     await page.waitForTimeout(5000);
-                    await waitAndHandleConsentFrame(page, request.url);
+                    await waitAndHandleConsentScreen(page, request.url);
                     // @ts-ignore
                     request.userData.waitingForConsent = false;
                     log.warning('Consent screen approved! We can continue scraping');

--- a/src/utils.js
+++ b/src/utils.js
@@ -264,25 +264,23 @@ const waiter = async (predicate, options = {}) => {
 const waitAndHandleConsentFrame = async (page, url) => {
     // TODO: Test if the new consent screen works well!
 
-    // Old consent, keeping as a reference if it comes back
-    /*
     const predicate = async () => {
-        for (const frame of page.mainFrame().childFrames()) {
-            if (frame.url().match(/consent\.google\.[a-z.]+/)) {
-                await frame.click('#introAgreeButton');
-                return true;
-            }
-        }
-    };
-    */
-    const predicate = async () => {
+        // handling consent page (usually shows up on startup)
         const consentButton = await page.$('[action*="https://consent.google.com/"] button');
         if (consentButton) {
             await consentButton.click();
+            await page.waitForNavigation();
             return true;
         }
+        // handling consent screen overlay in maps
+        // (this only happens rarely, but still happens)
+        for (const frame of page.mainFrame().childFrames()) {
+          if (frame.url().match(/consent\.google\.[a-z.]+/)) {
+              await frame.click('#introAgreeButton');
+              return true;
+          }
+        }
     };
-    
 
     await waiter(predicate, {
         timeout: 60000,


### PR DESCRIPTION
The consent screen was not detected (wrong URL regex).
After fixing the detection a couple of JS errors occured (concurrency issues).
Fix both issues.

Also sometimes the old consent screen (overlay) appeared again.
So bring back the old code to handle it.
(Note: I didn't test if handling the overlay works, because the overlay didn't occur in my
testing after changing the code, but the selectors seemed to match.)

Rename waitAndHandleConsentFrame() to waitAndHandleConsentScreen(), because mostly the screen occurs on its own page now.