### PR TITLE
Fix back navigation to details page

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -283,7 +283,7 @@ const navigateBack = async (page, pageLabel) => {
     await waiter(backButtonPresent, {
         timeout: 2000,
         pollInterval: 500,
-        timeoutErrorMeesage: `Waiting for backButton on ${pageLabel} page ran into a timeout after 2s on URL: ${page.url}`,
+        timeoutErrorMeesage: `Waiting for backButton on ${pageLabel} page ran into a timeout after 2s on URL: ${page.url()}`,
     });
     const navigationSucceeded = async () => {
         const backButton = await page.$(BACK_BUTTON_SEL);
@@ -298,7 +298,7 @@ const navigateBack = async (page, pageLabel) => {
     await waiter(navigationSucceeded, {
         timeout: 10000,
         pollInterval: 500,
-        timeoutErrorMeesage: `Waiting for back navigation on ${pageLabel} page ran into a timeout after 10s on URL: ${page.url}`,
+        timeoutErrorMeesage: `Waiting for back navigation on ${pageLabel} page ran into a timeout after 10s on URL: ${page.url()}`,
     });
 }
 

--- a/src/extractors.js
+++ b/src/extractors.js
@@ -275,6 +275,7 @@ const navigateBack = async (page, pageLabel) => {
     const title = await page.$(PLACE_TITLE_SEL);
     if (title) {
         log.info('[PLACE]: We are still on the details page -> no back navigation needed');
+        return;
     }
     const backButtonPresent = async () => {
         const backButton = await page.$(BACK_BUTTON_SEL);

--- a/src/extractors.js
+++ b/src/extractors.js
@@ -227,10 +227,6 @@ module.exports.extractAdditionalInfo = async ({ page }) => {
         } catch (e) {
             log.info(`[PLACE]: ${e}Additional info not parsed`);
         } finally {
-            const title = await page.$(PLACE_TITLE_SEL);
-            if (title) {
-                log.info('[PLACE]: We are still on the details page -> no back navigation needed');
-            }
             await navigateBack(page, 'additional info');
         }
     } else {
@@ -276,6 +272,10 @@ const removePersonalDataFromReviews = (reviews, personalDataOptions) => {
  * @param {string} pageLabel label for the current page for error messages
  */
 const navigateBack = async (page, pageLabel) => {
+    const title = await page.$(PLACE_TITLE_SEL);
+    if (title) {
+        log.info('[PLACE]: We are still on the details page -> no back navigation needed');
+    }
     const backButtonPresent = async () => {
         const backButton = await page.$(BACK_BUTTON_SEL);
         return backButton != null;


### PR DESCRIPTION
Clicking the back button on the additional info page and on the review page often had no effect which resulted in errors afterwards.
Fix this by clicking the back button repeatedly if the navigation doesn't take place.