### PR TITLE
Fix problem that back button is not found

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -289,7 +289,11 @@ const navigateBack = async (page, pageLabel) => {
     const navigationSucceeded = async () => {
         const backButton = await page.$(BACK_BUTTON_SEL);
         if (backButton) {
-            await backButton.click({ delay: 200 });
+            await backButton.evaluate((backButtonNode) => {
+                if (backButtonNode instanceof HTMLElement) {
+                    backButtonNode.click();
+                }
+            });
         }
         const title = await page.$(PLACE_TITLE_SEL);
         if (title) {


### PR DESCRIPTION
The back button was not found sometimes.

Reason (most probably):
In some cases Puppeteer clicked on the position where the button had been shortly before the click.
This way the burger menu item was clicked.
Solution: Directly click the DOM node of the button.

Additional benefit of the solution: If the element isn't present in the page anymore,
no error will occur (puppeteer won't complain about a removed element).