### PR TITLE
Remember Consent Cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "test-local": "mocha --file ./test/crawler.local.js",
         "test-platform": "mocha --file ./test/crawler.platform.js",
+        "postinstall": "patch-package",
         "start": "node ./src/main.js"
     },
     "repository": {
@@ -25,7 +26,8 @@
     "homepage": "https://github.com/drobnikj/crawler-google-places#readme",
     "dependencies": {
         "@turf/turf": "^5.1.6",
-        "apify": "^0.22.2"
+        "apify": "0.22.5",
+        "patch-package": "^6.4.7"
     },
     "devDependencies": {
         "@types/jquery": "^3.5.5",

--- a/patches/apify+0.22.5.patch
+++ b/patches/apify+0.22.5.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/apify/build/crawlers/basic_crawler.js b/node_modules/apify/build/crawlers/basic_crawler.js
+index 3ee6a55..4a12ce4 100644
+--- a/node_modules/apify/build/crawlers/basic_crawler.js
++++ b/node_modules/apify/build/crawlers/basic_crawler.js
+@@ -272,11 +272,16 @@ class BasicCrawler {
+         // Initialize AutoscaledPool before awaiting _loadHandledRequestCount(),
+         // so that the caller can get a reference to it before awaiting the promise returned from run()
+         // (otherwise there would be no way)
+-        this.autoscaledPool = new autoscaled_pool_1.default(this.autoscaledPoolOptions);
+-        if (this.useSessionPool) {
+-            this.sessionPool = await session_pool_1.openSessionPool(this.sessionPoolOptions);
++        // Making sure, that _init is executed max. once. Otherwise the same event listener would be registered twice in
++        // sessionPool.initialize(), which can lead to corrupted JSON files when persisting the state.
++        if (!this.initCalled) {
++            this.initCalled = true;
++            this.autoscaledPool = new autoscaled_pool_1.default(this.autoscaledPoolOptions);
++            if (this.useSessionPool) {
++                this.sessionPool = await session_pool_1.openSessionPool(this.sessionPoolOptions);
++            }
++            await this._loadHandledRequestCount();
+         }
+-        await this._loadHandledRequestCount();
+     }
+     /**
+      * @param {object} crawlingContext

--- a/src/main.js
+++ b/src/main.js
@@ -227,6 +227,7 @@ Apify.main(async () => {
             });
         },
         useSessionPool: true,
+        persistCookiesPerSession: true,
         // This is just passed to gotoFunction
         pageLoadTimeoutSec,
         // long timeout, because of long infinite scroll

--- a/src/places_crawler.js
+++ b/src/places_crawler.js
@@ -118,7 +118,7 @@ const setUpCrawler = ({ crawlerOptions, scrapingOptions, stats, errorSnapshotter
     return new Apify.PuppeteerCrawler({
         // We have to strip this otherwise SDK complains
         ...options,
-        gotoFunction: async ({ request, page }) => {
+        gotoFunction: async ({ request, page, session }) => {
             // @ts-ignore
             // eslint-disable-next-line no-underscore-dangle
             await page._client.send('Emulation.clearDeviceMetricsOverride');
@@ -146,7 +146,8 @@ const setUpCrawler = ({ crawlerOptions, scrapingOptions, stats, errorSnapshotter
                     // @ts-ignore
                     request.userData.waitingForConsent = true;
                     await page.waitForTimeout(5000);
-                    await waitAndHandleConsentScreen(page, request.url);
+                    const { persistCookiesPerSession } = options;
+                    await waitAndHandleConsentScreen(page, request.url, persistCookiesPerSession, session);
                     // @ts-ignore
                     request.userData.waitingForConsent = false;
                     log.warning('Consent screen approved! We can continue scraping');

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -30,6 +30,7 @@ const Apify = require('apify'); // eslint-disable-line no-unused-vars
  * @property {number} [maxConcurrency]
  * @property {Apify.LaunchPuppeteerFunction} launchPuppeteerFunction
  * @property {boolean} useSessionPool
+ * @property {boolean} persistCookiesPerSession
  * @property {number} pageLoadTimeoutSec
  * @property {number} handlePageTimeoutSecs
  * @property {number} maxRequestRetries


### PR DESCRIPTION
The Consent page was displayed everytime after opening the browser.
Reasons:
- the CrawlerOption persistCookiesPerSession wasn't set
- After setting it, still no code was executed to put it into the
session
- The SDK_SESSION_POOL_STATE.json was corrupted, because an event
listener to persist the state was added twice which lead to writing it
twice at the same time. This last point was only relevant after
stopping and restarting the crawler.

Fix all of those issues.

Notes: 
- Unfortunately I had to create a patch for Apify to fix the last point. I will also create a PR in that repo soon, so that we can hopefully remove the patch after the next Apify release.
- The expires date is sometimes written wrong into the SDK_SESSION_POOL_STATE.json which seems to be another Apify Bug, but the consent screen handling works in spite of that.