### PR TITLE
Fix outdated selector for empty results

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -6,3 +6,6 @@ exports.MAX_PAGE_RETRIES = 6;
 
 exports.PLACE_TITLE_SEL = 'h1[class*="header-title-title"]';
 exports.BACK_BUTTON_SEL = 'button[jsaction*=back], button[aria-label="Back"]';
+exports.NEXT_BUTTON_SELECTOR = '[jsaction="pane.paginationSection.nextPage"]';
+
+exports.NO_RESULT_XPATH = '//div[contains(text(), "No results found")]';

--- a/src/enqueue_places.js
+++ b/src/enqueue_places.js
@@ -8,11 +8,10 @@ const Stats = require('./stats'); // eslint-disable-line no-unused-vars
 const PlacesCache = require('./stats'); // eslint-disable-line no-unused-vars
 
 const { sleep, log } = Apify.utils;
-const { PLACE_TITLE_SEL } = require('./consts');
+const { PLACE_TITLE_SEL, NEXT_BUTTON_SELECTOR, NO_RESULT_XPATH } = require('./consts');
 const { waitForGoogleMapLoader, parseSearchPlacesResponseBody, parseZoomFromUrl } = require('./utils');
 const { checkInPolygon } = require('./polygon');
 
-const NEXT_BUTTON_SELECTOR = '[jsaction="pane.paginationSection.nextPage"]';
 const SEARCH_WAIT_TIME_MS = 30000;
 const CHECK_LOAD_OUTCOMES_EVERY_MS = 500;
 const PLACES_PER_PAGE = 20;
@@ -110,8 +109,8 @@ const waitForSearchResults = async (page) => {
             return { isBadQuery: true };
         }
 
-        const hasNoResults = await page.$('[class *= "section-no-result"');
-        if (hasNoResults) {
+        const hasNoResults = await page.$x(NO_RESULT_XPATH);
+        if (hasNoResults.length > 0) {
             return { hasNoResults: true };
         }
 
@@ -120,9 +119,7 @@ const waitForSearchResults = async (page) => {
             return { isDetailPage: true };
         }
 
-        const isNextPaginationDisabled = await page.evaluate((nextButtonSel) => {
-            return !!$(nextButtonSel).attr('disabled');
-        }, NEXT_BUTTON_SELECTOR);
+        const isNextPaginationDisabled = await page.$(`${NEXT_BUTTON_SELECTOR}:disabled`);
         if (isNextPaginationDisabled) {
             return { isNextPaginationDisabled: true };
         }


### PR DESCRIPTION
The crawler is not able to detect if there are no results because there is no such class as "[section-no-result](https://github.com/drobnikj/crawler-google-places/blob/master/src/enqueue_places.js#L113)" in the Google Maps page anymore. This leads to an infinite loop where the crawler repeatedly tries to enqueue zero items:
```
Cannot find place data in search.
Enqueued 0/0 places (correct location/total) + 0 ads
Cannot find place data in search.
Enqueued 0/0 places (correct location/total) + 0 ads
..
```
We can check for "No results found" instead using the XPATH `//div[contains(text(), "No results found")]` which can be defined conveniently in `consts.js`.

