### PR TITLE
Fix detection of the additional info page

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -367,7 +367,7 @@ module.exports.extractAdditionalInfo = async ({ page }) => {
     if (button) {
         try {
             await button.click({ delay: 200 });
-            await page.waitForSelector('div[class*="subtitle"]', { timeout: 30000 });
+            await page.waitForSelector(PLACE_TITLE_SEL, { timeout: 30000, hidden: true });
             result = await page.evaluate(() => {
                 /** @type {{[key: string]: any[]}} */
                 const innerResult = {};


### PR DESCRIPTION
The current selector for detecting the additional info page doesn't work e.g. for
place_id=ChIJX0TiOH9t2jERc787U2mFbZo .
(URL: 
https://www.google.com/maps/search/?api=1&query=place_id:ChIJX0TiOH9t2jERc787U2mFbZo&query_place_id=ChIJX0TiOH9t2jERc787U2mFbZo )

This leads to a broken JSON output containing:
```
"additionalInfo": {
    "": []
  },
```

This PR fixes it.