### PR TITLE
Fix edge cases for permanently closed flag

### DIFF
--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -102,6 +102,7 @@ module.exports.handlePlaceDetail = async (options) => {
 
     let totalScore = jsonData?.[4]?.[7] || null;
     let reviewsCount = jsonData?.[4]?.[8] || 0;
+    let permanentlyClosed = (jsonData?.[203]?.[1]?.[4]?.[0] === 'Permanently closed');
 
     // We fallback to HTML (might be good to do only)
     if (!totalScore) {
@@ -113,6 +114,10 @@ module.exports.handlePlaceDetail = async (options) => {
         reviewsCount = await page.evaluate(() => Number($('button[jsaction="pane.reviewChart.moreReviews"]')
             .text()
             .replace(/[^0-9]+/g, '')) || 0);
+    }
+
+    if (!permanentlyClosed) {
+        permanentlyClosed = await page.evaluate(() => $('#pane').text().includes('Permanently closed'));
     }
 
     // TODO: Add a backup and figure out why some direct start URLs don't load jsonData
@@ -145,7 +150,7 @@ module.exports.handlePlaceDetail = async (options) => {
 
     const detail = {
         ...pageData,
-        permanentlyClosed: jsonData?.[203]?.[1]?.[4]?.[0] === 'Permanently closed',
+        permanentlyClosed,
         totalScore,
         isAdvertisement,
         rank,


### PR DESCRIPTION
In PR #191 the source for the flag "permanently closed" was changed. It is now extracted from number 203 of the JSON data array (`jsonData?.[203]?.[1]?.[4]?.[0]`). This works well for most cases, for example these two places in Berlin
```
https://www.google.com/maps/place/?q=place_id:ChIJzxaPaexRqEcRLZw2jr74mQ8
https://www.google.com/maps/place/?q=place_id:ChIJe0A0-FVQqEcR7kn-3YZq7dg
```
Unfortunately there are some edge cases where number 203 contains only null values, for instance for the following two places in Vietnam
```
https://www.google.com/maps/place/?q=place_id:ChIJCZhZMkBLODERhhBTKOZusEo
https://www.google.com/maps/place/?q=place_id:ChIJD9PtlUNaODERMnAK5xM9kZ0
```
...which can be fetched by specifying the Google place ID in the "searchStringsArray" parameter...
```
"searchStringsArray": [
   "place_id:ChIJCZhZMkBLODERhhBTKOZusEo",
   "place_id:ChIJD9PtlUNaODERMnAK5xM9kZ0"
]
```
As a "fallback" solution for these exceptional edge cases we can check additionally (as before) if the text "Permanently closed" is contained in the `div#pane` element.
