### PR TITLE
Fixing Image scraping class

### DIFF
--- a/src/extractors.js
+++ b/src/extractors.js
@@ -594,7 +594,7 @@ module.exports.extractImages = async ({ page, maxImages }) => {
 
     let resultImageUrls;
 
-    const mainImageSel = '.section-hero-header-image-hero-container';
+    const mainImageSel = '[jsaction="pane.heroHeaderImage.click"]';
     const mainImage = await page.waitForSelector(mainImageSel);
 
     if (maxImages === 1) {


### PR DESCRIPTION
https://github.com/drobnikj/crawler-google-places/issues/196
Google removed .section-hero-header-image-hero-containe class.
To fix this we will use "[jsaction="pane.heroHeaderImage.click"]"