### PR TITLE
Fix additional-info extraction

### DIFF
--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -280,10 +280,10 @@ module.exports.extractAdditionalInfo = async ({ page, placeUrl }) => {
                 /** @type {{[key: string]: any[]}} */
                 const innerResult = {};
                 $('div[role="region"]').each((_, section) => {
-                    const key = $(section).find('div[class*="subtitle"]').text().trim();
+                    const key = $(section).find('*[class*="subtitle"]').text().trim();
                     /** @type {{[key: string]: boolean}[]} */
                     const values = [];
-                    $(section).find('div[aria-label]').each((_i, sub) => {
+                    $(section).find('li:has(span[aria-label])').each((_i, sub) => {
                         /** @type {{[key: string]: boolean}} */
                         const res = {};
                         const title = $(sub).text().trim();


### PR DESCRIPTION
The additional infos are not extracted anymore.

Example place_id, where it doesn't work:
ChIJ386XmIGTB0cR3YPBIkkQ2Ic

The extracted data looks like this in the JSON:
```
"additionalInfo": {
    "": []
  },
```

This PR fixes it.