### PR TITLE
Extract all categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The result for a single Google Place looks like this:
   "permanentlyClosed": false,
   "totalScore": 4.1,
   "placeId": "ChIJXRQlXoyUC0cRq5R4OBRKKxU",
+  "categories": [
+    "Restaurant",
+    "Bar"
+  ],
   "cid": "1525394349502272683",
   "url": "https://www.google.com/maps/place/The+PUB+Praha+2/@50.0761791,14.4261789,17z/data=!3m1!4b1!4m5!3m4!1s0x470b948c5e25145d:0x152b4a14387894ab!8m2!3d50.0761842!4d14.4283668?hl=en",
   "searchString": "place_id:ChIJXRQlXoyUC0cRq5R4OBRKKxU",

--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -152,6 +152,9 @@ module.exports.handlePlaceDetail = async (options) => {
     // How many we should scrape (otherwise we retry)
     const targetReviewsCount = Math.min(reviewsCount, maxReviews);
 
+    // extract categories
+    const categories = jsonData?.[13]
+
     const detail = {
         ...pageData,
         permanentlyClosed,
@@ -159,6 +162,7 @@ module.exports.handlePlaceDetail = async (options) => {
         isAdvertisement,
         rank,
         placeId: jsonData?.[78] || request.uniqueKey,
+        categories: request.userData.categories || categories,
         cid,
         url,
         searchPageUrl,

--- a/src/enqueue_places.js
+++ b/src/enqueue_places.js
@@ -105,6 +105,7 @@ const enqueuePlacesFromResponse = (options) => {
                             coords: placePaginationData.coords,
                             addressParsed: placePaginationData.addressParsed,
                             isAdvertisement: placePaginationData.isAdvertisement,
+                            categories: placePaginationData.categories
                         },
                     },
                     { forefront: true });

--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -18,6 +18,9 @@ const parseJsonResult = (placeData, isAdvertisement) => {
     if (!placeData) {
         return;
     }
+
+    const categories = placeData[13];
+
     // Some places don't have any address
     const addressDetail = placeData[183]?.[1];
     const addressParsed = {
@@ -41,6 +44,7 @@ const parseJsonResult = (placeData, isAdvertisement) => {
         addressParsed,
         isAdvertisement,
         website: placeData[7]?.[0] || null,
+        categories
     };
 }
 
@@ -116,6 +120,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             ? $('[data-section-id="pn0"].section-info-speak-numeral').attr('data-href').replace('tel:', '')
             : $("button[data-tooltip*='phone']").text().trim();
         const phoneAlt = $('button[data-item-id*=phone]').text().trim();
+        const categoryName = (jsonResult.categories.length > 0) ? jsonResult.categories[0] : '';
 
         return {
             title: $(placeTitleSel).text().trim(),
@@ -124,7 +129,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             menu: $("button[aria-label='Menu']").text().replaceAll('Menu','').trim() || null,
             // Getting from JSON now
             // totalScore: $('span.section-star-display').eq(0).text().trim(),
-            categoryName: $('[jsaction="pane.rating.category"]').text().trim(),
+            categoryName: $('[jsaction="pane.rating.category"]').text().trim() || categoryName,
             address: address || addressAlt || addressAlt2 || null,
             locatedIn: secondaryAddressLine || secondaryAddressLineAlt || secondaryAddressLineAlt2 || null,
             ...jsonResult.addressParsed || {},


### PR DESCRIPTION
This PR modifies the scraper to fetch all categories in addition to the main category `categoryName`.

The `categoryName` which is extracted by the crawler is one of multiple categories stored internally by Google Maps. If we examine the JSON data we can find all categories in block number 13. For example "The PUB Praha 2" in Prague which has the place ID `ChIJXRQlXoyUC0cRq5R4OBRKKxU` is not only classified as a "Restaurant", but also as a "Bar". Another example is the Jaffa restaurant in Prague which has the place ID `ChIJ0xa6j02VC0cRa7hlPXhPtlI`. It has one `categoryName="Lebanese restaurant"` but 9 categories in total ("Lebanese restaurant", "Barbecue restaurant", "Falafel restaurant", "Halal restaurant", "Hookah bar", "Mediterranean restaurant", "Middle Eastern restaurant", "Mutton barbecue restaurant", "Vegan restaurant").

Example input parameters for the two examples: 
```
"searchStringsArray": [
  "place_id:ChIJXRQlXoyUC0cRq5R4OBRKKxU",
  "place_id:ChIJ0xa6j02VC0cRa7hlPXhPtlI"
]
```

