### PR TITLE
Fix for places which have no categories at all

### DIFF
--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -120,7 +120,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             ? $('[data-section-id="pn0"].section-info-speak-numeral').attr('data-href').replace('tel:', '')
             : $("button[data-tooltip*='phone']").text().trim();
         const phoneAlt = $('button[data-item-id*=phone]').text().trim();
-        const categoryName = ((jsonResult.categories) && (jsonResult.categories.length > 0)) ? jsonResult.categories[0] : '';
+        const categoryName = ((jsonResult.categories) && (jsonResult.categories.length > 0)) ? jsonResult.categories[0] : null;
 
         return {
             title: $(placeTitleSel).text().trim(),

--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -120,7 +120,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             ? $('[data-section-id="pn0"].section-info-speak-numeral').attr('data-href').replace('tel:', '')
             : $("button[data-tooltip*='phone']").text().trim();
         const phoneAlt = $('button[data-item-id*=phone]').text().trim();
-        const categoryName = (jsonResult.categories.length > 0) ? jsonResult.categories[0] : '';
+        const categoryName = ((jsonResult.categories) && (jsonResult.categories.length > 0)) ? jsonResult.categories[0] : '';
 
         return {
             title: $(placeTitleSel).text().trim(),


### PR DESCRIPTION
PR https://github.com/drobnikj/crawler-google-places/pull/214 introduced a bug 🐞   for places which have absolutely no categories, for example for this place in São Paulo which is named "Escola De Futebol":
```
https://www.google.com/maps/place/?q=place_id:ChIJXbCThiHj3JQRBHtcWwdXq8Y
```
In this case `categories` has a `null` value and it produces the error
```
Error: Operation failed. Error detail: Evaluation failed: TypeError: Cannot read property 'length' of null
```