### PR TITLE
Fix max crawled places

### DIFF
--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -162,7 +162,7 @@ module.exports.handlePlaceDetail = async (options) => {
         isAdvertisement,
         rank,
         placeId: jsonData?.[78] || request.uniqueKey,
-        categories: request.userData.categories || categories,
+        categories: request.userData.categories || categories,
         cid,
         url,
         searchPageUrl,
@@ -210,7 +210,7 @@ module.exports.handlePlaceDetail = async (options) => {
     await Apify.pushData(detail);
     stats.places();
     log.info(`[PLACE]: Place scraped successfully --- ${url}`);
-    const shouldScrapeMore = maxCrawledPlacesTracker.setScraped();
+    const shouldScrapeMore = maxCrawledPlacesTracker.setScraped(searchString);
     if (!shouldScrapeMore) {
         log.warning(`[SEARCH]: Finishing scraping because we reached maxCrawledPlaces `
             // + `currently: ${maxCrawledPlacesTracker.enqueuedPerSearch[searchKey]}(for this search)/${maxCrawledPlacesTracker.enqueuedTotal}(total) `

--- a/src/enqueue_places.js
+++ b/src/enqueue_places.js
@@ -91,7 +91,7 @@ const enqueuePlacesFromResponse = (options) => {
                     continue;
                 }
                 if (exportPlaceUrls) {
-                    if (!maxCrawledPlacesTracker.canScrapeMore()) {
+                    if (!maxCrawledPlacesTracker.canScrapeMore(searchString)) {
                         return result;
                     }
                     const wasAlreadyPushed = exportUrlsDeduper?.testDuplicateAndAdd(placePaginationData.placeId);

--- a/src/error-snapshotter.js
+++ b/src/error-snapshotter.js
@@ -41,7 +41,7 @@ module.exports = class ErrorSnapshotter {
      * Optionally, you can name the action for nicer logging, otherwise name of the error is used
      * These functions can be nested, in that case only one snapshot is produced (for the bottom error)
      * @param {Puppeteer.Page | string} pageOrHtml Puppeteer page or HTML
-     * @param {() => Puppeteer.} fn Function to execute
+     * @param {() => Promise<any>} fn Function to execute
      * @param {{
      *      name?: string,
      *      returnError?: boolean,
@@ -57,6 +57,7 @@ module.exports = class ErrorSnapshotter {
         try {
             return await fn();
         } catch (e) {
+            /** @type {any} */
             let err = e;
             // We don't want the Error: text, also we have to count with Error instances and string errors
             const errMessage = err.message || err;

--- a/src/export-urls-deduper.js
+++ b/src/export-urls-deduper.js
@@ -9,7 +9,7 @@ module.exports = class ExportUrlsDeduper {
         this.dedupSet = new Set();
     }
 
-    async initialize(events) {
+    async initialize(/** @type {any} */ events) {
         this.allPlaces = await this.loadFromStore();
 
         events.on('persistState', async () => {

--- a/src/max-crawled-places.js
+++ b/src/max-crawled-places.js
@@ -41,7 +41,7 @@ module.exports = class MaxCrawledPlacesTracker {
 
     /**
      * Returns true if we can still enqueue more for this search string
-     * @param {string} [searchString]
+     * @param {string} searchString
      * @returns {boolean}
      */
     canEnqueueMore(searchString) {
@@ -59,7 +59,7 @@ module.exports = class MaxCrawledPlacesTracker {
      * Increments a counter for enqueued requests
      * Returns true if the requests count was incremented
      * and the request should be really enqueued, false if not
-     * @param {string} [searchString]
+     * @param {string} searchString
      * @returns {boolean}
      */
     setEnqueued(searchString) {
@@ -81,7 +81,7 @@ module.exports = class MaxCrawledPlacesTracker {
 
     /**
      * Returns true if we can still scrape more for this search string
-     * @param {string} [searchString]
+     * @param {string} searchString
      * @returns {boolean}
      */
      canScrapeMore(searchString) {
@@ -99,7 +99,7 @@ module.exports = class MaxCrawledPlacesTracker {
      * Increments a counter for scraped requests
      * Returns true if the requests count was incremented
      * and we should continue to scrape for this search, false if not
-     * @param {string} [searchString]
+     * @param {string} searchString
      * @returns {boolean}
      */
      setScraped(searchString) {

--- a/src/max-crawled-places.js
+++ b/src/max-crawled-places.js
@@ -26,6 +26,7 @@ module.exports = class MaxCrawledPlacesTracker {
     async initialize(events) {
         const loadedState = /** @type {typedefs.MaxCrawledPlacesState | undefined}  */
             (await Apify.getValue(MAX_CRAWLED_PLACES_STATE_RECORD_NAME));
+
         if (loadedState) {
             this.enqueuedTotal = loadedState.enqueuedTotal;
             this.enqueuedPerSearch = loadedState.enqueuedPerSearch;
@@ -122,7 +123,12 @@ module.exports = class MaxCrawledPlacesTracker {
     async persist() {
         await Apify.setValue(
             MAX_CRAWLED_PLACES_STATE_RECORD_NAME,
-            { enqueuedTotal: this.enqueuedTotal, enqueuedPerSearch: this.enqueuedPerSearch }
+            {
+                enqueuedTotal: this.enqueuedTotal,
+                enqueuedPerSearch: this.enqueuedPerSearch,
+                scrapedTotal: this.scrapedTotal,
+                scrapedPerSearch: this.scrapedPerSearch,
+            }
         );
     }
 }

--- a/src/places_crawler.js
+++ b/src/places_crawler.js
@@ -59,6 +59,7 @@ const handlePageFunctionExtended = async ({ pageContext, scrapingOptions, helper
                     searchString,
                     requestQueue: crawler.requestQueue,
                     request,
+                    session,
                     helperClasses,
                     scrapingOptions,
                     crawler,

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,9 +94,9 @@ const parseStartUrlsFromFile = async (fileUrl) => {
     let startUrls = [];
 
     if (isGoogleSpreadsheetFile(fileUrl)) {
-        const dowloadUrl = convertGoogleSheetsUrlToCsvDownload(fileUrl);
-        if (dowloadUrl) {
-            startUrls = await fetchRowsFromCsvFile(dowloadUrl)
+        const downloadUrl = convertGoogleSheetsUrlToCsvDownload(fileUrl);
+        if (downloadUrl) {
+            startUrls = await fetchRowsFromCsvFile(downloadUrl)
         } else {
             log.warning(`WRONG INPUT: Google Sheets URL cannot be converted to CSV. `)
         }


### PR DESCRIPTION
Fixes #219

I've encountered strange error which originates in `const responseBody = await response.buffer();` of `enqueue_places.js` (currently line 70). The error message stated: 'Session closed. Most likely the page has been closed'.
I've wrapped the whole section into try-catch block and marked current session as bad in the catch section. I'm not sure whether this is a proper reaction for this case but actor continued scraping, reaching `maxCrawledPlaces` limit and storing all results into the dataset (the same error was logged repeatedly but all requests finished successfully).

Another issue related directly to the usage of `maxCrawledPlaces` originated in wrong usage of `MaxCrawledPlacesTracker.setScraped` method. It modifies crawled places counter and it was used in cases where no place was saved into the dataset.