### PR TITLE
Fixed search click for language iw and RTL alike

### DIFF
--- a/src/enqueue_places.js
+++ b/src/enqueue_places.js
@@ -225,7 +225,18 @@ module.exports.enqueueAllPlaceDetails = async ({
     }
 
     await sleep(5000);
-    await page.click('#searchbox-searchbutton');
+    try {
+        await page.click('#searchbox-searchbutton');
+    } catch (e) {
+        log.warning(`click#searchbox-searchbutton ${e?.message}`);
+        try {
+            const retryClickSearchButton = await page.$('#searchbox-searchbutton');
+            await retryClickSearchButton.evaluate(b => b.click());
+        } catch (eOnRetry) {
+            log.warning(`retryClickSearchButton ${eOnRetry?.message}`);
+            await page.keyboard.press('Enter');
+        }
+    }
     await sleep(5000);
     await waitForGoogleMapLoader(page);
 


### PR DESCRIPTION
Hardware click on search button fails only from apify cloud and only for `iw` language, so one of the three: scrolling into view, getting bounding box or controlling mouse pointer fails under unique Puppeteer-OS-Environment combination, no good reason to find out exactly why in more details.
As a solution added fallback to retry with software click (tested and works) and on top of it another fallback to press Enter key in case if both clicks failed (also works).
All other UI interactions work as expected, proof: https://console.apify.com/view/runs/Ww9ip1gXccKPboW3q
Code snipped below for quick reference:
```
    try {
        await page.click('#searchbox-searchbutton');
    } catch (e) {
        log.warning(`click#searchbox-searchbutton ${e?.message}`);
        try {
            const retryClickSearchButton = await page.$('#searchbox-searchbutton');
            await retryClickSearchButton.evaluate(b => b.click());
        } catch (eOnRetry) {
            log.warning(`retryClickSearchButton ${eOnRetry?.message}`);
            await page.keyboard.press('Enter');
        }
    }
```
