### PR TITLE
Extract opening hours from JS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-02-17
+*Fixes*
+- `openingHours` extraction works in almost all cases now (search URLs and URLs with place IDs will always work).
+
 # 2022-01-12
 - Start URLs now correctly work from uploaded CSV files or Google Sheets. It uses to trim part of the URL.
 

--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -170,7 +170,7 @@ module.exports.handlePlaceDetail = async (options) => {
         location: coordinates, // keeping backwards compatible even though coordinates is better name
         scrapedAt: new Date().toISOString(),
         ...includeHistogram ? extractPopularTimes({ jsonData }) : {},
-        openingHours: includeOpeningHours ? await extractOpeningHours({ page }) : undefined,
+        openingHours: includeOpeningHours ? await extractOpeningHours({ page, jsonData }) : undefined,
         peopleAlsoSearch: includePeopleAlsoSearch ? await extractPeopleAlsoSearch({ page }) : undefined,
         additionalInfo: additionalInfo ? await extractAdditionalInfo({ page, placeUrl: url }) : undefined,
         reviewsCount,

--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -190,10 +190,19 @@ module.exports.extractPopularTimes = ({ jsonData }) => {
 
 /**
  * @param {{
- *    page: Puppeteer.Page
+ *    page: Puppeteer.Page,
+ *    jsonData: any
  * }} options
  */
-module.exports.extractOpeningHours = async ({ page }) => {
+module.exports.extractOpeningHours = async ({ page, jsonData }) => {
+    if (jsonData?.[34]?.[1]?.[0] && jsonData?.[34]?.[1]?.[1]) {
+        return jsonData[34][1].map((/** @type {any[]} */ entry) => ({
+            // adding a "," to make it consistent to extracting data from the DOM (old format)
+            day: `${entry[0]},`,
+            // replace "–" by " to " to make it consistent to extracting data from the DOM
+            hours: entry[1].map((/** @type {string} */ hourInterval) => hourInterval.replace("–", " to ")).join(", ")
+        }));
+    }
     let result;
     const openingHoursSel = '.section-open-hours-container.section-open-hours-container-hoverable';
     const openingHoursSelAlt = '.section-open-hours-container.section-open-hours';


### PR DESCRIPTION
Opening hours sometimes didn't get extracted (https://github.com/drobnikj/crawler-google-places/issues/164).

This PR fixes the issue for most cases by extracting the opening hours directly from a JS variable.
According to a comment in the code it only won't work for some kinds of direct URLs, but search and place IDs will work fine.
If the opening hours can't be extracted from the JS variable, they will be tried to be extracted from the DOM as before.

I tested it with the following start URLs:
```
"https://www.google.com/maps/place/?q=place_id:ChIJa8oexDVDOToRq-Zbla5kHEw",
 "https://www.google.com/maps/place/?q=place_id:ChIJzUrRNwVpOToRS5IsdZavgtw", 
 "https://www.google.com/maps/place/Bihar+852124,+India/",  
"https://www.google.com/maps/place/McDonald's/@41.5907075,1.6160677,17z/data=!4m5!3m4!1s0x12a4427544614d0b:0x9a331380ec9f79dd!8m2!3d41.5907035!4d1.6183124",
"https://www.google.com/maps/place/Village+d'Ung/@48.870321,2.3107268,19z/data=!3m1!4b1!4m5!3m4!1s0x47e66fc59046af91:0x5591629ab3d68623!8m2!3d48.870321!4d2.311274",
"https://www.google.com/maps/place/Anytime+Fitness+Igualada/@41.5799921,1.6160404,17z/data=!3m1!4b1!4m5!3m4!1s0x12a469041cf1bdf9:0xa1385c3d013d1b3e!8m2!3d41.5799871!4d1.6182281?hl=en",
"https://www.google.com/maps/place/Restaurante+La+Tagliatella+%7C+Manresa/@41.7314496,1.8176481,15z/data=!4m5!3m4!1s0x0:0xfc653ca88dfd7f0c!8m2!3d41.7254609!4d1.8247446"
```
The third one doesn't have opening hours.
The last 4 are from the mentioned issue.