### PR TITLE
Extract location field from JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-02-28
+*Fixes*
+- `location` extraction works in (almost) all cases now (search URLs and URLs with place IDs will always work).
+
 # 2020-02-21
 *Features*
 - Added `oneReviewPerRow` to input to enable expanding reviews one per output row

--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -168,7 +168,8 @@ module.exports.handlePlaceDetail = async (options) => {
         url,
         searchPageUrl,
         searchString,
-        location: coordinates, // keeping backwards compatible even though coordinates is better name
+        // keeping backwards compatible even though coordinates is better name
+        location: coordinates || pageData?.location?.lat ? pageData.location : null,
         scrapedAt: new Date().toISOString(),
         ...includeHistogram ? extractPopularTimes({ jsonData }) : {},
         openingHours: includeOpeningHours ? await extractOpeningHours({ page, jsonData }) : undefined,

--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -140,6 +140,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             phone: phone || phoneAlt || null,
             // Wasn't able to find this in the JSON
             temporarilyClosed: $('#pane').text().includes('Temporarily closed'),
+            location: jsonResult.coords,
         };
     }, PLACE_TITLE_SEL, jsonResult || {});
 };


### PR DESCRIPTION
In some rare cases the location field was not scraped, e.g. this usually happened when using the following start URLs locally (Indian postcodes):

```
"https://www.google.com/maps/place/Bihar+852124,+India/",
"https://www.google.com/maps/place/Rajasthan+302037%2C+India?hl=en",
"https://www.google.com/maps/place/Gujarat+384003%2C+India?hl=en",
"https://www.google.com/maps/place/Assam+786623%2C+India?hl=en",
"https://www.google.com/maps/place/Rajasthan+303604%2C+India",
"https://www.google.com/maps/place/Kerala+676501%2C+India",
"https://www.google.com/maps/place/Rajasthan+303504%2C+India",
"https://www.google.com/maps/place/Assam+782427%2C+India",
"https://www.google.com/maps/place/Kerala+676501%2C+India",
"https://www.google.com/maps/place/Rajasthan+303504%2C+India"
```

This PR fixes the issue (at least for the above case) by using the already extracted location data from a JS variable.