### PR TITLE
Enqueue start requests over `500` limit asynchronously

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -1,7 +1,11 @@
 exports.DEFAULT_TIMEOUT = 60 * 1000; // 60 sec
 
-// Max scrollnig results, this might change in the future
+// Max scrolling results, this might change in the future.
 exports.MAX_PLACES_PER_PAGE = 120;
+
+// Max start requests that can be fed to the request queue synchronously.
+exports.MAX_START_REQUESTS_SYNC = 500;
+exports.ASYNC_START_REQUESTS_INTERVAL = 20000;
 
 exports.LISTING_PAGINATION_KEY = 'lisState';
 exports.MAX_PAGE_RETRIES = 6;

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,8 @@ const ExportUrlsDeduper = require('./export-urls-deduper');
 const { prepareSearchUrlsAndGeo } = require('./search');
 const { createStartRequestsWithWalker } = require('./walker');
 const { makeInputBackwardsCompatible, validateInput, getValidStartRequests, adjustInput } = require('./input-validation');
-const { parseRequestsFromStartUrls } = require('./utils');
+const { parseRequestsFromStartUrls, enqueueStartRequests, enqueueStartRequestsAsync } = require('./utils');
+const { MAX_START_REQUESTS_SYNC } = require('./consts');
 
 const { log } = Apify.utils;
 
@@ -178,16 +179,17 @@ Apify.main(async () => {
         log.info(`Prepared ${startRequests.length} Start URLs (showing max 10):`);
         console.dir(startRequests.map((r) => r.url).slice(0, 10));
 
-        for (const request of startRequests) {
-            if (request.userData?.label === 'detail') {
-                // TODO: Here we enqueue place details so we need to check for maxCrawledPlaces
-                if (!maxCrawledPlacesTracker.setEnqueued()) {
-                    log.warning(`Reached maxCrawledPlaces ${maxCrawledPlaces}, not enqueueing any more`);
-                    break;
-                }
-            }
-            await requestQueue.addRequest(request);
-        }
+        /**
+         * Start requests will be shifted and enqueued from this array asynchronously.
+         * Actor's migration will be handled by default as `requestsToEnqueue`
+         * are built from `startRequests` and these are created from the input on each run.
+         */
+        const requestsToEnqueue = [...startRequests];
+
+        const enqueueRequests = enqueueStartRequests(maxCrawledPlacesTracker, maxCrawledPlaces, requestQueue);
+
+        await enqueueRequests(requestsToEnqueue.splice(0, MAX_START_REQUESTS_SYNC));
+        enqueueStartRequestsAsync(requestsToEnqueue, enqueueRequests);
 
         await Apify.setValue('START-REQUESTS', startRequests);
         const apifyPlatformKVLink = 'link: https://api.apify.com/v2/key-value-stores/'

--- a/src/main.js
+++ b/src/main.js
@@ -186,10 +186,10 @@ Apify.main(async () => {
          */
         const requestsToEnqueue = [...startRequests];
 
-        const enqueueRequests = enqueueStartRequests(maxCrawledPlacesTracker, maxCrawledPlaces, requestQueue);
+        const syncStartRequests = requestsToEnqueue.splice(0, MAX_START_REQUESTS_SYNC);
+        await enqueueStartRequests(syncStartRequests, requestQueue, maxCrawledPlacesTracker, maxCrawledPlaces);
 
-        await enqueueRequests(requestsToEnqueue.splice(0, MAX_START_REQUESTS_SYNC));
-        enqueueStartRequestsAsync(requestsToEnqueue, enqueueRequests);
+        enqueueStartRequestsAsync(requestsToEnqueue, requestQueue, maxCrawledPlacesTracker, maxCrawledPlaces);
 
         await Apify.setValue('START-REQUESTS', startRequests);
         const apifyPlatformKVLink = 'link: https://api.apify.com/v2/key-value-stores/'

--- a/src/utils.js
+++ b/src/utils.js
@@ -468,6 +468,12 @@ module.exports.enqueueStartRequestsAsync = (requests, requestQueue, maxCrawledPl
         }
     }
 
+    /**
+     * We're using `setInterval` instead of `setTimeout` since `setTimeout` freezes
+     * the run in local development as all the remaining requests are enqueued at once.
+     * It is most likely caused by the implementation of `RequestQueue` which responds
+     * immediately in a local run.
+     */
     const intervalId = setInterval(async () => {
         const nextGroup = asyncRequestGroups.shift();
         if (nextGroup) {


### PR DESCRIPTION
Fixes #262

This performance optimization gets significant only for large number or search queries. I tested it with ~30K queries that originally took ±1.5 minutes before the first result appeared in the dataset. Limiting the number of synchronous starts requests reduced the time to ± 45 seconds for 10K, 20K or 30K requests.

See the example [INPUT.json](https://gist.github.com/lhotanok/50070e27c01e37bdf49a2d4f9a101548).