### PR TITLE
Fix temporarily closed extraction

### DIFF
--- a/src/detail_page_handle.js
+++ b/src/detail_page_handle.js
@@ -181,7 +181,7 @@ module.exports.handlePlaceDetail = async (options) => {
     }
 
     if (!permanentlyClosed) {
-        permanentlyClosed = await page.evaluate(() => $('#pane').text().includes('Permanently closed'));
+        permanentlyClosed = await page.evaluate(() => $('#pane,.skqShb').text().includes('Permanently closed'));
     }
 
     // TODO: Add a backup and figure out why some direct start URLs don't load jsonData

--- a/src/extractors/general.js
+++ b/src/extractors/general.js
@@ -169,7 +169,7 @@ module.exports.extractPageData = async ({ page, jsonData }) => {
             website: jsonResult.website,
             phone: phone || phoneAlt || null,
             // Wasn't able to find this in the JSON
-            temporarilyClosed: $('#pane').text().includes('Temporarily closed'),
+            temporarilyClosed: $('#pane,.skqShb').text().includes('Temporarily closed'),
             location: jsonResult.coords,
         };
     }, PLACE_TITLE_SEL, jsonResult || {});


### PR DESCRIPTION
The extraction of the _temporarily closed_ flag didn't work anymore.
This PR fixes it.

Example URL: https://www.google.com/maps/place/?q=place_id:ChIJQcAXtd8udTER8aikz7qMoEI


It also updates the backup version for the _permanently closed_ extraction,
although the _permanently closed_ extraction worked fine.