### PR TITLE
Improve additional info extraction for hotels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2022-08-16
+*Fixes*
+- Improve extraction of additional infos for hotels.
+
 # 2022-08-15
 *Fixes*
 - Fixed actor sometimes finishing prematurely when there were still requests in the queue (caused by the new background enqueueing system)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 # 2022-08-05
 *Fixes*
 - Fixed reviews duplications that sometimes happened.
+- Fixed extraction of the temporarilyClosed field.
 
 # 2022-08-03
 *Fixes*

--- a/src/place-extractors/general.js
+++ b/src/place-extractors/general.js
@@ -361,15 +361,15 @@ module.exports.extractAdditionalInfo = async ({ page, placeUrl, jsonData }) => {
             await navigateBack(page, 'additional info', placeUrl);
         }
     } else {
-        // DIV for "Hotel details" has the CSS class "fPmgbe-eTC1nf-vg2oCf-haAclf"
-        const hotel_avail_amenities = await page.$$eval('div[class="fPmgbe-eTC1nf-vg2oCf-haAclf"] div:not([aria-disabled=true]) > span',
+        // DIV for "Hotel details" has the CSS class "WKLD0c"
+        const hotel_avail_amenities = await page.$$eval('div[class="WKLD0c"] div:not([aria-disabled=true]) > span',
             (elements) => {
                 return elements.map((element) => {
                     return element.textContent ? element.textContent.trim() : ''
                 });
             }
         );
-        const hotel_disabled_amenities = await page.$$eval('div[class="fPmgbe-eTC1nf-vg2oCf-haAclf"] div[aria-disabled=true] > span',
+        const hotel_disabled_amenities = await page.$$eval('div[class="WKLD0c"] div[aria-disabled=true] > span',
             (elements) => {
                 return elements.map((element) => {
                     return element.textContent ? element.textContent.trim() : ''


### PR DESCRIPTION
The element for extracting the additional infos from hotels (hotel amenities) has changes.

This PR updates the corresponding CSS selector, although the hotel amenities are usually extracted directly from Javascript which still worked.